### PR TITLE
Enable/Disable redirect rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "redirector",
   "description": "Dynamic URL Redirector",
   "private": true,
-  "version": "0.8.4",
+  "version": "0.8.5",
   "type": "module",
   "scripts": {
     "dev": "wxt",

--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -28,7 +28,7 @@ export default defineBackground(() => {
   >()
 
   function getRedirectUrl(tabId: number, url: string) {
-    const rule = rules.filter((rule) => rule?.enabled ?? true).find((rule) => matchRule(rule, url).match)
+    const rule = rules.filter((rule) => rule.enabled ?? true).find((rule) => matchRule(rule, url).match)
     if (!rule) {
       return {}
     }

--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -4,6 +4,7 @@ export default defineBackground(() => {
   interface Rule {
     from: string
     to: string
+    enabled: boolean
   }
 
   let rules: Rule[] = []
@@ -27,7 +28,7 @@ export default defineBackground(() => {
   >()
 
   function getRedirectUrl(tabId: number, url: string) {
-    const rule = rules.find((rule) => matchRule(rule, url).match)
+    const rule = rules.filter((rule) => rule.enabled).find((rule) => matchRule(rule, url).match)
     if (!rule) {
       return {}
     }

--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -4,7 +4,7 @@ export default defineBackground(() => {
   interface Rule {
     from: string
     to: string
-    enabled: boolean
+    enabled?: boolean
   }
 
   let rules: Rule[] = []
@@ -28,7 +28,7 @@ export default defineBackground(() => {
   >()
 
   function getRedirectUrl(tabId: number, url: string) {
-    const rule = rules.filter((rule) => rule.enabled).find((rule) => matchRule(rule, url).match)
+    const rule = rules.filter((rule) => rule?.enabled ?? true).find((rule) => matchRule(rule, url).match)
     if (!rule) {
       return {}
     }

--- a/src/entrypoints/options/components/Dataset.svelte
+++ b/src/entrypoints/options/components/Dataset.svelte
@@ -92,8 +92,8 @@
             />
           </TableCell>
           <TableCell>
-            <Checkbox bind:checked={rule.disabled}>
-              {#if rule.disabled}
+            <Checkbox bind:checked={rule.enabled}>
+              {#if rule.enabled}
                 <CheckIcon class="h-4 w-4" />
               {/if}
             </Checkbox>
@@ -129,8 +129,8 @@
                 : 'Auto'}
           </TableCell>
           <TableCell>
-            <Checkbox checked={rule.disabled} disabled>
-              {#if rule.disabled}
+            <Checkbox checked={rule.enabled} disabled>
+              {#if rule.enabled}
                 <CheckIcon class="h-4 w-4" />
               {/if}
             </Checkbox>

--- a/src/entrypoints/options/components/Dataset.svelte
+++ b/src/entrypoints/options/components/Dataset.svelte
@@ -18,6 +18,12 @@
 
   let edit: null | number = null
 
+  // retro-compatibility
+  $rules.map((rule) => {
+    rule.enabled = rule.enabled ?? true
+    return rule
+  })
+
   function changeEdit(index: number) {
     if (edit === index) {
       edit = null
@@ -52,6 +58,10 @@
         reader.onload = (e) => {
           const json = JSON.parse(e.target?.result as string)
           $rules = uniqBy([...json, ...$rules], (it) => it.from)
+          $rules.map((rule) => {
+            rule.enabled = rule.enabled ?? true
+            return rule
+          })
           toast.success('Imported rules')
         }
         reader.readAsText(file)
@@ -93,7 +103,7 @@
           </TableCell>
           <TableCell>
             <Checkbox bind:checked={rule.enabled}>
-              {#if rule?.enabled ?? true}
+              {#if rule.enabled}
                 <CheckIcon class="h-4 w-4" />
               {/if}
             </Checkbox>
@@ -130,7 +140,7 @@
           </TableCell>
           <TableCell>
             <Checkbox checked={rule.enabled} disabled>
-              {#if rule?.enabled ?? true}
+              {#if rule.enabled}
                 <CheckIcon class="h-4 w-4" />
               {/if}
             </Checkbox>

--- a/src/entrypoints/options/components/Dataset.svelte
+++ b/src/entrypoints/options/components/Dataset.svelte
@@ -93,7 +93,7 @@
           </TableCell>
           <TableCell>
             <Checkbox bind:checked={rule.enabled}>
-              {#if rule.enabled}
+              {#if rule?.enabled ?? true}
                 <CheckIcon class="h-4 w-4" />
               {/if}
             </Checkbox>
@@ -130,7 +130,7 @@
           </TableCell>
           <TableCell>
             <Checkbox checked={rule.enabled} disabled>
-              {#if rule.enabled}
+              {#if rule?.enabled ?? true}
                 <CheckIcon class="h-4 w-4" />
               {/if}
             </Checkbox>

--- a/src/entrypoints/options/components/Dataset.svelte
+++ b/src/entrypoints/options/components/Dataset.svelte
@@ -18,11 +18,8 @@
 
   let edit: null | number = null
 
-  // retro-compatibility
-  $rules.map((rule) => {
-    rule.enabled = rule.enabled ?? true
-    return rule
-  })
+  
+  handleDataRetro()
 
   function changeEdit(index: number) {
     if (edit === index) {
@@ -58,16 +55,20 @@
         reader.onload = (e) => {
           const json = JSON.parse(e.target?.result as string)
           $rules = uniqBy([...json, ...$rules], (it) => it.from)
-          $rules.map((rule) => {
-            rule.enabled = rule.enabled ?? true
-            return rule
-          })
+          handleDataRetro()
           toast.success('Imported rules')
         }
         reader.readAsText(file)
       }
     }
     input.click()
+  }
+
+  function handleDataRetro() {
+    $rules.map((rule) => {
+      rule.enabled = rule.enabled ?? true
+      return rule
+    })
   }
 </script>
 

--- a/src/entrypoints/options/components/Dataset.svelte
+++ b/src/entrypoints/options/components/Dataset.svelte
@@ -69,6 +69,7 @@
   <TableHeader>
     <TableRow>
       <TableHead>Mode</TableHead>
+      <TableHead>Enabled</TableHead>
       <TableHead>From</TableHead>
       <TableHead>To</TableHead>
       <TableHead class="text-right">Action</TableHead>
@@ -88,6 +89,9 @@
               placeholder="Select mode"
               class="w-36"
             />
+          </TableCell>
+          <TableCell>
+            {!rule.disabled ? 'yes' : 'no'}
           </TableCell>
           <TableCell>
             <Input type="text" class="w-full" bind:value={rule.from} />
@@ -118,6 +122,9 @@
               : rule.mode === 'url-pattern'
                 ? 'URL Pattern'
                 : 'Auto'}
+          </TableCell>
+          <TableCell>
+            {!rule.disabled ? 'yes' : 'no'}
           </TableCell>
           <TableCell>
             {rule.from}

--- a/src/entrypoints/options/components/Dataset.svelte
+++ b/src/entrypoints/options/components/Dataset.svelte
@@ -18,9 +18,6 @@
 
   let edit: null | number = null
 
-  
-  handleDataRetro()
-
   function changeEdit(index: number) {
     if (edit === index) {
       edit = null
@@ -54,21 +51,16 @@
         const reader = new FileReader()
         reader.onload = (e) => {
           const json = JSON.parse(e.target?.result as string)
-          $rules = uniqBy([...json, ...$rules], (it) => it.from)
-          handleDataRetro()
+          $rules = uniqBy([...json, ...$rules], (it) => it.from).map((rule) => {
+            rule.enabled = rule.enabled ?? true
+            return rule
+          })
           toast.success('Imported rules')
         }
         reader.readAsText(file)
       }
     }
     input.click()
-  }
-
-  function handleDataRetro() {
-    $rules.map((rule) => {
-      rule.enabled = rule.enabled ?? true
-      return rule
-    })
   }
 </script>
 

--- a/src/entrypoints/options/components/Dataset.svelte
+++ b/src/entrypoints/options/components/Dataset.svelte
@@ -2,6 +2,7 @@
   import { rules } from '../store'
   import { Button } from '$lib/components/ui/button'
   import { Input } from '$lib/components/ui/input'
+	import { Checkbox } from '$lib/components/ui/checkbox';
   import { CheckIcon, EditIcon, TrashIcon } from 'lucide-svelte'
   import {
     Table,
@@ -91,7 +92,11 @@
             />
           </TableCell>
           <TableCell>
-            {!rule.disabled ? 'yes' : 'no'}
+            <Checkbox bind:checked={rule.disabled}>
+              {#if rule.disabled}
+                <CheckIcon class="h-4 w-4" />
+              {/if}
+            </Checkbox>
           </TableCell>
           <TableCell>
             <Input type="text" class="w-full" bind:value={rule.from} />
@@ -124,7 +129,11 @@
                 : 'Auto'}
           </TableCell>
           <TableCell>
-            {!rule.disabled ? 'yes' : 'no'}
+            <Checkbox checked={rule.disabled} disabled>
+              {#if rule.disabled}
+                <CheckIcon class="h-4 w-4" />
+              {/if}
+            </Checkbox>
           </TableCell>
           <TableCell>
             {rule.from}

--- a/src/entrypoints/options/components/Form.svelte
+++ b/src/entrypoints/options/components/Form.svelte
@@ -26,7 +26,7 @@
 
   function addRedirect() {
     if (from && to) {
-      $rules = [{ from: from.trim(), to: to.trim(), mode }, ...$rules]
+      $rules = [{ from: from.trim(), to: to.trim(), disabled: false, mode }, ...$rules]
       from = ''
       to = ''
     }
@@ -39,7 +39,7 @@
     }
     if (from && to && origin) {
       const r = matchRule(
-        { from: from.trim(), to: to.trim(), mode },
+        { from: from.trim(), to: to.trim(), disabled: false, mode },
         origin.trim(),
       )
       console.log(from, origin, to, r)

--- a/src/entrypoints/options/components/Form.svelte
+++ b/src/entrypoints/options/components/Form.svelte
@@ -19,6 +19,7 @@
   let to = ''
   let origin = ''
   let mode: MatchRule['mode'] = 'regex'
+  let enabled: boolean = true
   let redirect: MatchResult = {
     match: false,
     url: '',
@@ -26,7 +27,7 @@
 
   function addRedirect() {
     if (from && to) {
-      $rules = [{ from: from.trim(), to: to.trim(), disabled: false, mode }, ...$rules]
+      $rules = [{ from: from.trim(), to: to.trim(), enabled, mode }, ...$rules]
       from = ''
       to = ''
     }
@@ -39,7 +40,7 @@
     }
     if (from && to && origin) {
       const r = matchRule(
-        { from: from.trim(), to: to.trim(), disabled: false, mode },
+        { from: from.trim(), to: to.trim(), enabled, mode },
         origin.trim(),
       )
       console.log(from, origin, to, r)

--- a/src/entrypoints/options/store.ts
+++ b/src/entrypoints/options/store.ts
@@ -10,8 +10,8 @@ function createSyncStorage<T>(
     browser.storage.sync.get(key).then((result) => {
       set(
         transform
-          ? transform(result[key] || initialValue)
-          : result[key] || initialValue,
+          ? transform(result[key] as T || initialValue)
+          : result[key] as T || initialValue,
       )
     })
   })

--- a/src/entrypoints/options/store.ts
+++ b/src/entrypoints/options/store.ts
@@ -1,10 +1,18 @@
 import { MatchRule } from '$lib/url'
 import { writable } from 'svelte/store'
 
-function createSyncStorage<T>(key: string, initialValue: T) {
+function createSyncStorage<T>(
+  key: string,
+  initialValue: T,
+  transform?: (value: T) => T,
+) {
   const { subscribe, set, update } = writable<T>(initialValue, () => {
     browser.storage.sync.get(key).then((result) => {
-      set(result[key] || initialValue)
+      set(
+        transform
+          ? transform(result[key] || initialValue)
+          : result[key] || initialValue,
+      )
     })
   })
 
@@ -21,4 +29,6 @@ function createSyncStorage<T>(key: string, initialValue: T) {
   }
 }
 
-export const rules = createSyncStorage<MatchRule[]>('rules', [])
+export const rules = createSyncStorage<MatchRule[]>('rules', [], (value) =>
+  value.map((rule) => ({ ...rule, enabled: rule.enabled ?? true })),
+)

--- a/src/lib/__tests__/url.test.ts
+++ b/src/lib/__tests__/url.test.ts
@@ -60,7 +60,6 @@ describe('should using url params', () => {
         {
           from: 'https://youtu.be/:id',
           to: 'https://www.youtube.com/watch?v={{pathname.groups.id}}',
-          enabled: true,
         },
         'https://youtu.be/sRHOrI59tRQ',
       ),
@@ -75,7 +74,6 @@ describe('should using url params', () => {
         {
           from: 'https://www.google.com/url?q=:url&(.*)',
           to: '{{search.groups.url}}',
-          enabled: true,
         },
         'https://www.google.com/url?q=https://archiveofourown.org/works/46606894&amp;sa=D&amp;source=editors&amp;ust=1730028678389922&amp;usg=AOvVaw0bnG9SKYDnSYYyEmj-X1c-',
       ),
@@ -90,7 +88,6 @@ describe('should using url params', () => {
         {
           from: 'https://duckduckgo.com/?*&q=:id&*',
           to: 'https://www.google.com/search?q={{search.groups.id}}',
-          enabled: true,
         },
         'https://duckduckgo.com/?t=h_&q=js&ia=web',
       ),
@@ -105,7 +102,6 @@ describe('should using url params', () => {
         {
           from: 'https://youtu.be/:id',
           to: 'https://www.youtube.com/watch?v={{pathname.groups.id}}',
-          enabled: true,
         },
         'https://youtu.be/sRHOrI59tRQ',
       ),
@@ -118,7 +114,6 @@ describe('should using url params', () => {
     const rule: MatchRule = {
       from: 'https:\\/\\/www.google.com\\/url\\?q=(((?!google.com).)*?)&.*',
       to: '$1',
-      enabled: true,
     }
     expect(
       matchRule(
@@ -140,7 +135,6 @@ describe('should using url params', () => {
     const rule: MatchRule = {
       from: 'https://link.zhihu.com/?target=:url',
       to: '{{search.groups.url}}',
-      enabled: true,
     }
     expect(
       matchRule(
@@ -156,7 +150,6 @@ describe('should using url params', () => {
     const rule: MatchRule = {
       from: 'https://www.google.com/url?q=:url&*',
       to: '{{search.groups.url}}',
-      enabled: true,
     }
     let url =
       'https://www.google.com/url?q=https://www.google.com/url?q%3Dhttps://archiveofourown.org/works/46606894%26amp;sa%3DD%26amp;source%3Deditors%26amp;ust%3D1730032801876547%26amp;usg%3DAOvVaw1sQgvzpIHgk4ky36GUr0Qg&sa=D&source=docs&ust=1730032804915522&usg=AOvVaw0EzJyyDgDMcHFs2nxdHMBo'
@@ -175,7 +168,6 @@ describe('should using url params', () => {
     const rule: MatchRule = {
       from: 'https://www.bilibili.com/video/(.+?)\\?',
       to: 'https://www.bilibili.com/video/$1',
-      enabled: true,
     }
     expect(
       matchRule(rule, 'https://www.bilibili.com/video/BV1Qy4y1o71y?test=123'),

--- a/src/lib/__tests__/url.test.ts
+++ b/src/lib/__tests__/url.test.ts
@@ -8,6 +8,7 @@ describe('regex match', () => {
         {
           from: '^https://duckduckgo.com/\\?.*&q=(.*?)(&.*)?$',
           to: 'https://www.google.com/search?q=$1',
+          enabled: true
         },
         'https://duckduckgo.com/?t=h_&q=js&ia=web',
       ),
@@ -23,6 +24,7 @@ describe('regex match', () => {
         {
           from: '^https://duckduckgo.com/\\?.*&q=(.*?)(&.*)?$',
           to: 'https://www.google.com/search?q=$1',
+          enabled: true
         },
         'https://duckduckgo.com/?q=js&ia=web',
       ),
@@ -40,6 +42,7 @@ describe('match real rule', () => {
         {
           from: 'https://youtu.be/(.*)',
           to: 'https://www.youtube.com/watch?v=$1',
+          enabled: true
         },
         'https://youtu.be/sRHOrI59tRQ',
       ),
@@ -57,6 +60,7 @@ describe('should using url params', () => {
         {
           from: 'https://youtu.be/:id',
           to: 'https://www.youtube.com/watch?v={{pathname.groups.id}}',
+          enabled: true,
         },
         'https://youtu.be/sRHOrI59tRQ',
       ),
@@ -71,6 +75,7 @@ describe('should using url params', () => {
         {
           from: 'https://www.google.com/url?q=:url&(.*)',
           to: '{{search.groups.url}}',
+          enabled: true,
         },
         'https://www.google.com/url?q=https://archiveofourown.org/works/46606894&amp;sa=D&amp;source=editors&amp;ust=1730028678389922&amp;usg=AOvVaw0bnG9SKYDnSYYyEmj-X1c-',
       ),
@@ -85,6 +90,7 @@ describe('should using url params', () => {
         {
           from: 'https://duckduckgo.com/?*&q=:id&*',
           to: 'https://www.google.com/search?q={{search.groups.id}}',
+          enabled: true,
         },
         'https://duckduckgo.com/?t=h_&q=js&ia=web',
       ),
@@ -99,6 +105,7 @@ describe('should using url params', () => {
         {
           from: 'https://youtu.be/:id',
           to: 'https://www.youtube.com/watch?v={{pathname.groups.id}}',
+          enabled: true,
         },
         'https://youtu.be/sRHOrI59tRQ',
       ),
@@ -111,6 +118,7 @@ describe('should using url params', () => {
     const rule: MatchRule = {
       from: 'https:\\/\\/www.google.com\\/url\\?q=(((?!google.com).)*?)&.*',
       to: '$1',
+      enabled: true,
     }
     expect(
       matchRule(
@@ -132,6 +140,7 @@ describe('should using url params', () => {
     const rule: MatchRule = {
       from: 'https://link.zhihu.com/?target=:url',
       to: '{{search.groups.url}}',
+      enabled: true,
     }
     expect(
       matchRule(
@@ -147,6 +156,7 @@ describe('should using url params', () => {
     const rule: MatchRule = {
       from: 'https://www.google.com/url?q=:url&*',
       to: '{{search.groups.url}}',
+      enabled: true,
     }
     let url =
       'https://www.google.com/url?q=https://www.google.com/url?q%3Dhttps://archiveofourown.org/works/46606894%26amp;sa%3DD%26amp;source%3Deditors%26amp;ust%3D1730032801876547%26amp;usg%3DAOvVaw1sQgvzpIHgk4ky36GUr0Qg&sa=D&source=docs&ust=1730032804915522&usg=AOvVaw0EzJyyDgDMcHFs2nxdHMBo'
@@ -165,6 +175,7 @@ describe('should using url params', () => {
     const rule: MatchRule = {
       from: 'https://www.bilibili.com/video/(.+?)\\?',
       to: 'https://www.bilibili.com/video/$1',
+      enabled: true,
     }
     expect(
       matchRule(rule, 'https://www.bilibili.com/video/BV1Qy4y1o71y?test=123'),

--- a/src/lib/components/ui/checkbox/checkbox.svelte
+++ b/src/lib/components/ui/checkbox/checkbox.svelte
@@ -1,15 +1,7 @@
 <script lang="ts">
 	import { cn } from "$lib/utils";
 	import { Checkbox } from "bits-ui";
-	// import { HTMLInputAttributes } from "svelte/elements";
-    // import { CheckboxProps } from "bits-ui";
 
-    // type $$Props = CheckboxProps;
-    // type $$Props = HTMLInputAttributes;
-
-    // export let checked: $$Props["checked"] = undefined;
-    // export let disabled: $$Props["disabled"] = undefined;
-    // let className: $$Props["class"] = undefined;
     export let checked: boolean | undefined
     
 </script>

--- a/src/lib/components/ui/checkbox/checkbox.svelte
+++ b/src/lib/components/ui/checkbox/checkbox.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import { cn } from "$lib/utils";
+	import { Checkbox } from "bits-ui";
+	// import { HTMLInputAttributes } from "svelte/elements";
+    // import { CheckboxProps } from "bits-ui";
+
+    // type $$Props = CheckboxProps;
+    // type $$Props = HTMLInputAttributes;
+
+    // export let checked: $$Props["checked"] = undefined;
+    // export let disabled: $$Props["disabled"] = undefined;
+    // let className: $$Props["class"] = undefined;
+    export let checked: boolean | undefined
+    
+</script>
+
+<Checkbox.Root
+    class={cn("border-muted bg-background peer inline-flex size-[25px] items-center justify-center rounded-md border transition-all duration-150 ease-in-out active:scale-[0.98]")}
+    bind:checked
+    {...$$restProps}
+>
+	<slot />
+</Checkbox.Root>

--- a/src/lib/components/ui/checkbox/index.ts
+++ b/src/lib/components/ui/checkbox/index.ts
@@ -1,0 +1,5 @@
+import Root from "./checkbox.svelte"
+
+export {
+    Root as Checkbox
+}

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -5,7 +5,7 @@ export interface MatchRule {
   from: string
   to: string
   mode?: 'regex' | 'url-pattern'
-  disabled: boolean
+  enabled: boolean
 }
 
 export interface MatchResult {
@@ -55,7 +55,7 @@ function isURLPatternMatch(rule: MatchRule, url: string): MatchResult {
 }
 
 export function matchRule(rule: MatchRule, url: string): MatchResult {
-  if (rule.disabled) {
+  if (!rule.enabled) {
     return { match: false, url: url }
   }
 

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -5,6 +5,7 @@ export interface MatchRule {
   from: string
   to: string
   mode?: 'regex' | 'url-pattern'
+  disabled: boolean
 }
 
 export interface MatchResult {
@@ -54,6 +55,10 @@ function isURLPatternMatch(rule: MatchRule, url: string): MatchResult {
 }
 
 export function matchRule(rule: MatchRule, url: string): MatchResult {
+  if (rule.disabled) {
+    return { match: false, url: url }
+  }
+
   const list =
     rule.mode === 'regex'
       ? [isRegexMatch]

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -55,10 +55,6 @@ function isURLPatternMatch(rule: MatchRule, url: string): MatchResult {
 }
 
 export function matchRule(rule: MatchRule, url: string): MatchResult {
-  if (!rule.enabled) {
-    return { match: false, url: url }
-  }
-
   const list =
     rule.mode === 'regex'
       ? [isRegexMatch]

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -5,7 +5,7 @@ export interface MatchRule {
   from: string
   to: string
   mode?: 'regex' | 'url-pattern'
-  enabled: boolean
+  enabled?: boolean
 }
 
 export interface MatchResult {


### PR DESCRIPTION
I installed this Chrome extension on my PC after Google removed my old one. I personally like the minimal approach, with only the necessary features.

I use this extension mainly to test oauth flows and to redirect from the production URL of my apps to the testing/local environments. To do this, I need to create many rules starting from the same URL ("from" column) with different destination URLs. 

I just needed a new feature: a simple checkbox to enable/disable a redirect rule. I decided to try and implement it myself. Let me know your feedback if it can be added to the main extension. 

### Description of the change

The checkbox is simple. From the table, you can enable/disable each rule. To maintain retro-compatibility with the old versions, I consider each "undefined" state as true. This way, the rule is considered "enabled."

### Test

Here is also a short video with the new feature tested locally: https://www.loom.com/share/45625f2982b54499972f6b810e9342a0?sid=11e7e53c-44ea-4e48-94b3-eab8b1849ddd

The imported file I used (rules_old.json) contains rules exported before this change. This way i tested the retro-compatibility with already stored rules

The exported file at the end of the video has this new format
```json
[
  {
    "from": "https://search.yahoo.com/",
    "to": "http://www.google.com",
    "mode": "regex",
    "enabled": false
  }
]
```