### PR TITLE
fix: update e2e test pattern to match files correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "postinstall": "wxt prepare",
     "test": "pnpm test:unit && pnpm test:e2e",
     "test:unit": "vitest run",
-    "test:e2e": "playwright test src/.*/*.e2e.test.ts"
+    "test:e2e": "playwright test"
   },
   "devDependencies": {
     "@hono/node-server": "^1.19.6",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "postinstall": "wxt prepare",
     "test": "pnpm test:unit && pnpm test:e2e",
     "test:unit": "vitest run",
-    "test:e2e": "playwright test src/**/*.e2e.test.ts"
+    "test:e2e": "playwright test src/.*/*.e2e.test.ts"
   },
   "devDependencies": {
     "@hono/node-server": "^1.19.6",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testMatch: "src/**/*.e2e.test.ts",
+});


### PR DESCRIPTION
Fix test regex pattern to avoid: `SyntaxError: Invalid regular expression: /src/**/*.e2e.test.ts/gi: Nothing to repeat` when running `pnpm run test:e2e`