### PR TITLE
feat: add local storage fallback

### DIFF
--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -1,14 +1,36 @@
 import { getRedirectUrl, store } from '$lib/redirect'
+import {
+  readRulesFromMode,
+  readRulesStorageMode,
+  RULES_KEY,
+  RULES_STORAGE_MODE_KEY,
+  type RulesStorageMode,
+} from '$lib/storage'
 import { MatchRule } from '$lib/url'
 
 export default defineBackground(() => {
-  browser.storage.sync.get('rules').then((data: { rules?: MatchRule[] }) => {
-    store.rules = data.rules || []
+  let activeStorageMode: RulesStorageMode = 'sync'
+
+  async function reloadRulesFromActiveMode() {
+    store.rules = await readRulesFromMode(activeStorageMode)
+  }
+
+  readRulesStorageMode().then(async (mode) => {
+    activeStorageMode = mode
+    await reloadRulesFromActiveMode()
   })
 
-  browser.storage.sync.onChanged.addListener((changes) => {
-    if (changes.rules) {
-      store.rules = changes.rules.newValue as MatchRule[]
+  browser.storage.onChanged.addListener(async (changes, areaName) => {
+    if (areaName === 'local' && changes[RULES_STORAGE_MODE_KEY]) {
+      const nextMode = changes[RULES_STORAGE_MODE_KEY].newValue as
+        | RulesStorageMode
+        | undefined
+      activeStorageMode = nextMode === 'local' ? 'local' : 'sync'
+      await reloadRulesFromActiveMode()
+      return
+    }
+    if (areaName === activeStorageMode && changes[RULES_KEY]) {
+      store.rules = (changes[RULES_KEY].newValue as MatchRule[] | undefined) ?? []
     }
   })
 

--- a/src/entrypoints/options/App.svelte
+++ b/src/entrypoints/options/App.svelte
@@ -8,6 +8,7 @@
   import { ExternalLinkIcon } from '@lucide/svelte'
   import {
     addRule,
+    isStorageQuotaExceededError,
     rules,
   } from './store'
   import { toast } from 'svelte-sonner'
@@ -27,6 +28,10 @@
       toast.success('Rule added')
       return
     } catch (error) {
+      if (isStorageQuotaExceededError(error)) {
+        toast.error('Storage quota exceeded. You can switch to Local mode in the menu.')
+        return
+      }
       toast.error('Failed to save rule')
       return
     }

--- a/src/entrypoints/options/App.svelte
+++ b/src/entrypoints/options/App.svelte
@@ -6,7 +6,10 @@
   import { Button } from '$lib/components/ui/button'
   import { Toaster } from '$lib/components/ui/sonner'
   import { ExternalLinkIcon } from '@lucide/svelte'
-  import { rules } from './store'
+  import {
+    addRule,
+    rules,
+  } from './store'
   import { toast } from 'svelte-sonner'
   import type { MatchRule } from '$lib/url'
 
@@ -18,9 +21,15 @@
     addDialog.open = true
   }
 
-  function handleSaveNewRule(rule: MatchRule) {
-    $rules = [rule, ...$rules]
-    toast.success('Rule added')
+  async function handleSaveNewRule(rule: MatchRule) {
+    try {
+      await addRule(rule)
+      toast.success('Rule added')
+      return
+    } catch (error) {
+      toast.error('Failed to save rule')
+      return
+    }
   }
 </script>
 

--- a/src/entrypoints/options/App.test.ts
+++ b/src/entrypoints/options/App.test.ts
@@ -1,0 +1,90 @@
+import * as storage from "$lib/storage";
+import type { MatchRule } from "$lib/url";
+import { commands } from "@vitest/browser/context";
+import { fakeBrowser } from "@webext-core/fake-browser";
+import { toast } from "svelte-sonner";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-svelte";
+import App from "./App.svelte";
+
+describe("quota handling", () => {
+  beforeEach(async () => {
+    Reflect.set(globalThis, "browser", fakeBrowser);
+
+    const existingRule: MatchRule = {
+      mode: "regex",
+      enabled: true,
+      from: "https://example.com/from-existing",
+      to: "https://example.com/to-existing",
+    };
+    await storage.writeRulesStorageMode("sync");
+    await storage.writeRulesToMode("sync", [existingRule]);
+  });
+
+  afterEach(() => {
+    Reflect.deleteProperty(globalThis, "browser");
+    vi.restoreAllMocks();
+  });
+
+  it("shows local mode suggestion toast when add, edit, and import fail in sync mode due to quota", async () => {
+    const quotaMessage =
+      "Storage quota exceeded. You can switch to Local mode in the menu.";
+    const quotaError = new Error(
+      "Resource::kQuotaBytesPerItem quota exceeded",
+    );
+    const originalSyncSet = browser.storage.sync.set.bind(
+      browser.storage.sync,
+    );
+    vi.spyOn(browser.storage.sync, "set").mockImplementation(
+      async (value) => {
+        if ("rules" in value) {
+          throw quotaError;
+        }
+        return originalSyncSet(value);
+      },
+    );
+    const toastErrorSpy = vi.spyOn(toast, "error");
+
+    const screen = render(App);
+
+    await screen.getByTitle("Add Rule").click();
+    await screen
+      .getByTitle("Match URL")
+      .fill("https://example.com/from-add");
+    await screen
+      .getByTitle("Redirect URL")
+      .fill("https://example.com/to-add");
+    await screen.getByTitle("Save").click();
+
+    await screen.getByTitle("Edit").click();
+    await screen
+      .getByTitle("Match URL")
+      .fill("https://example.com/from-edit");
+    await screen.getByTitle("Save").click();
+    await screen.getByTitle("Cancel").click();
+
+    await Promise.all([
+      commands.waitForUpload({
+        name: "rules.json",
+        mimeType: "application/json",
+        text: JSON.stringify([
+          {
+            mode: "regex",
+            enabled: true,
+            from: "https://example.com/from-import",
+            to: "https://example.com/to-import",
+          } satisfies MatchRule,
+        ]),
+      }),
+      screen.getByTitle("Actions").click(),
+      screen.getByTitle("Import").click(),
+    ]);
+
+    expect(toastErrorSpy).toHaveBeenCalledTimes(3);
+    expect(
+      toastErrorSpy.mock.calls.every(
+        ([message]) => message === quotaMessage,
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/entrypoints/options/components/Dataset.svelte
+++ b/src/entrypoints/options/components/Dataset.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import {
+    isStorageQuotaExceededError,
+    replaceRules,
     rules,
     rulesStorageMode,
     setRulesStorageMode,
@@ -119,6 +121,11 @@
           : 'Switched to sync storage',
       )
     } catch (error) {
+      if (isStorageQuotaExceededError(error)) {
+        toast.error('Failed to switch storage mode. Storage quota exceeded.')
+        console.error('Failed to switch storage mode', error)
+        return
+      }
       toast.error('Failed to switch storage mode')
       console.error('Failed to switch storage mode', error)
     } finally {
@@ -133,14 +140,24 @@
     input.onchange = async (e) => {
       const file = (e.target as HTMLInputElement).files?.[0]
       if (file) {
-        const text = await file.text()
-        const json = JSON.parse(text)
-        $rules = uniqBy([...json, ...$rules], (it) => it.from).map((rule) => {
-          rule.enabled = rule.enabled ?? true
-          return rule
-        })
-        actionsMenuOpen = false
-        toast.success('Imported rules')
+        try {
+          const text = await file.text()
+          const json = JSON.parse(text)
+          const nextRules = uniqBy([...json, ...$rules], (it) => it.from).map((rule) => {
+            rule.enabled = rule.enabled ?? true
+            return rule
+          })
+          await replaceRules(nextRules)
+          actionsMenuOpen = false
+          toast.success('Imported rules')
+        } catch (error) {
+          if (isStorageQuotaExceededError(error)) {
+            toast.error('Storage quota exceeded. You can switch to Local mode in the menu.')
+            return
+          }
+          toast.error('Failed to import rules')
+          console.error('Failed to import rules', error)
+        }
       }
     }
     input.click()

--- a/src/entrypoints/options/components/Dataset.svelte
+++ b/src/entrypoints/options/components/Dataset.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-  import { rules } from '../store'
+  import {
+    rules,
+    rulesStorageMode,
+    setRulesStorageMode,
+  } from '../store'
   import { Button } from '$lib/components/ui/button'
   import { Checkbox } from '$lib/components/ui/checkbox'
   import * as DropdownMenu from '$lib/components/ui/dropdown-menu'
@@ -36,6 +40,7 @@
     rule?: MatchRule
   }>({ open: false })
   let actionsMenuOpen = $state(false)
+  let switchingStorageMode = $state(false)
 
   function sortRules(upOrDown: string, index: number) {
     if (upOrDown == 'up') {
@@ -100,7 +105,28 @@
     toast.success('Exported rules')
   }
 
-  function importRules() {
+  async function toggleStorageMode() {
+    if (switchingStorageMode) {
+      return
+    }
+    switchingStorageMode = true
+    const nextMode = $rulesStorageMode === 'sync' ? 'local' : 'sync'
+    try {
+      await setRulesStorageMode(nextMode)
+      toast.success(
+        nextMode === 'local'
+          ? 'Switched to local storage'
+          : 'Switched to sync storage',
+      )
+    } catch (error) {
+      toast.error('Failed to switch storage mode')
+      console.error('Failed to switch storage mode', error)
+    } finally {
+      switchingStorageMode = false
+    }
+  }
+
+  async function importRules() {
     const input = document.createElement('input')
     input.type = 'file'
     input.accept = 'application/json'
@@ -137,7 +163,19 @@
         <EllipsisVertical class="h-4 w-4" />
       </Button>
     </DropdownMenu.Trigger>
-    <DropdownMenu.Content class="w-40" sideOffset={8}>
+    <DropdownMenu.Content class="w-56" sideOffset={8}>
+      <div class="flex items-center gap-1 px-1 pb-1">
+        <DropdownMenu.CheckboxItem
+          checked={$rulesStorageMode === 'sync'}
+          onclick={toggleStorageMode}
+          class="flex-1"
+          title="Use sync storage"
+          disabled={switchingStorageMode}
+        >
+          Sync Storage
+        </DropdownMenu.CheckboxItem>
+      </div>
+      <DropdownMenu.Separator />
       <DropdownMenu.Item onclick={exportRules} title="Export">Export</DropdownMenu.Item>
       <DropdownMenu.Item onclick={importRules} title="Import">Import</DropdownMenu.Item>
       <DropdownMenu.Separator />

--- a/src/entrypoints/options/components/Dataset.svelte
+++ b/src/entrypoints/options/components/Dataset.svelte
@@ -64,10 +64,22 @@
     }
   }
 
-  function handleSave(rule: MatchRule, index?: number) {
+  async function handleSave(rule: MatchRule, index?: number) {
     if (index !== undefined) {
-      $rules[index] = rule
-      toast.success('Rule updated')
+      const nextRules = [...$rules]
+      nextRules[index] = rule
+      try {
+        await replaceRules(nextRules)
+        toast.success('Rule updated')
+      } catch (error) {
+        if (isStorageQuotaExceededError(error)) {
+          toast.error('Storage quota exceeded. You can switch to Local mode in the menu.')
+          throw error
+        }
+        toast.error('Failed to update rule')
+        console.error('Failed to update rule', error)
+        throw error
+      }
     }
   }
 

--- a/src/entrypoints/options/components/Dataset.test.ts
+++ b/src/entrypoints/options/components/Dataset.test.ts
@@ -2,9 +2,11 @@ import { it, expect, beforeEach, afterEach, describe, vi } from 'vitest'
 import Dataset from './Dataset.svelte'
 import { render } from 'vitest-browser-svelte'
 import { fakeBrowser } from '@webext-core/fake-browser'
-import { rules } from '../store'
+import { rules, setRulesStorageMode } from '../store'
 import { MatchRule } from '$lib/url'
 import { commands } from '@vitest/browser/context'
+import { toast } from 'svelte-sonner'
+import * as storage from '$lib/storage'
 
 beforeEach(() => {
   Reflect.set(globalThis, 'browser', fakeBrowser)
@@ -13,7 +15,43 @@ beforeEach(() => {
 afterEach(() => {
   rules.set([])
   Reflect.deleteProperty(globalThis, 'browser')
-  vi.clearAllMocks()
+  vi.restoreAllMocks()
+})
+
+describe('Storage Mode', () => {
+  it('switching local -> sync fails gracefully on sync quota limit', async () => {
+    const localRule: MatchRule = {
+      mode: 'regex',
+      enabled: true,
+      from: 'https://example.com/from-local',
+      to: 'https://example.com/to-local',
+    }
+    rules.set([localRule])
+    await setRulesStorageMode('local')
+
+    const quotaError = new Error('quota exceeded in sync storage')
+    const originalSyncSet = browser.storage.sync.set.bind(browser.storage.sync)
+    vi.spyOn(browser.storage.sync, 'set').mockImplementation(async (value) => {
+      if ('rules' in value) {
+        throw quotaError
+      }
+      return originalSyncSet(value)
+    })
+    const toastErrorSpy = vi.spyOn(toast, 'error')
+
+    const screen = render(Dataset)
+    await screen.getByTitle('Actions').click()
+    const syncStorageToggle = screen.getByTitle('Use sync storage')
+    await expect.element(syncStorageToggle).toHaveAttribute('data-state', 'unchecked')
+
+    await syncStorageToggle.click()
+
+    expect(toastErrorSpy).toHaveBeenCalledWith(
+      'Failed to switch storage mode. Storage quota exceeded.',
+    )
+    await expect.element(syncStorageToggle).toHaveAttribute('data-state', 'unchecked')
+    await expect(storage.readRulesStorageMode()).resolves.toBe('local')
+  })
 })
 
 describe('List', () => {

--- a/src/entrypoints/options/components/RuleDialog.svelte
+++ b/src/entrypoints/options/components/RuleDialog.svelte
@@ -45,7 +45,7 @@
     index?: number
     allRules: MatchRule[]
     onClose: () => void
-    onSave: (rule: MatchRule, index?: number) => void
+    onSave: (rule: MatchRule, index?: number) => void | Promise<void>
   }
 
   let { open = $bindable(), rule, index, allRules, onClose, onSave }: Props = $props()
@@ -104,19 +104,23 @@
     }
   })
 
-  function handleSave() {
+  async function handleSave() {
     if (formState.from && formState.to) {
-      onSave(
-        {
-          from: formState.from.trim(),
-          to: formState.to.trim(),
-          enabled: formState.enabled,
-          mode: formState.mode,
-          testUrl: formState.testUrl.trim() || undefined,
-        },
-        index,
-      )
-      onClose()
+      try {
+        await onSave(
+          {
+            from: formState.from.trim(),
+            to: formState.to.trim(),
+            enabled: formState.enabled,
+            mode: formState.mode,
+            testUrl: formState.testUrl.trim() || undefined,
+          },
+          index,
+        )
+        onClose()
+      } catch {
+        // The parent handler reports save errors via toast.
+      }
     }
   }
 </script>

--- a/src/entrypoints/options/store.test.ts
+++ b/src/entrypoints/options/store.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { fakeBrowser } from '@webext-core/fake-browser'
+import type { MatchRule } from '$lib/url'
+
+describe('setRulesStorageMode', () => {
+  beforeEach(() => {
+    Reflect.set(globalThis, 'browser', fakeBrowser)
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    Reflect.deleteProperty(globalThis, 'browser')
+    vi.restoreAllMocks()
+  })
+
+  it('switching storage mode migrates rules into the target mode', async () => {
+    const storage = await import('$lib/storage')
+    const optionsStore = await import('./store')
+
+    const localRule: MatchRule = {
+      mode: 'regex',
+      enabled: true,
+      from: 'https://example.com/from-local',
+      to: 'https://example.com/to-local',
+    }
+
+    await storage.writeRulesStorageMode('local')
+    await storage.writeRulesToMode('local', [localRule])
+
+    await optionsStore.setRulesStorageMode('sync')
+
+    await expect(storage.readRulesStorageMode()).resolves.toBe('sync')
+    await expect(storage.readRulesFromMode('sync')).resolves.toEqual([localRule])
+  })
+})

--- a/src/entrypoints/options/store.ts
+++ b/src/entrypoints/options/store.ts
@@ -1,34 +1,87 @@
-import { MatchRule } from '$lib/url'
-import { writable } from 'svelte/store'
+import {
+  normalizeRules,
+  readRulesFromMode,
+  readRulesStorageMode,
+  type RulesStorageMode,
+  writeRulesStorageMode,
+  writeRulesToMode,
+} from "$lib/storage";
+import { MatchRule } from "$lib/url";
+import { get, writable } from "svelte/store";
 
-function createSyncStorage<T>(
-  key: string,
-  initialValue: T,
-  transform?: (value: T) => T,
-) {
-  const { subscribe, set, update } = writable<T>(initialValue, () => {
-    browser.storage.sync.get(key).then((result) => {
-      set(
-        transform
-          ? transform(result[key] as T || initialValue)
-          : result[key] as T || initialValue,
-      )
-    })
-  })
+const rulesStorageModeState = writable<RulesStorageMode>("sync");
+const rulesState = writable<MatchRule[]>([]);
 
-  return {
-    subscribe,
-    set: (value: T) => {
-      set(value)
-      browser.storage.sync.set({ [key]: value })
-    },
-    update: (value: T) => {
-      update((value) => value)
-      browser.storage.sync.set({ [key]: value })
-    },
+let initialized = false;
+let loadingPromise: Promise<void> | undefined;
+
+async function ensureInitialized() {
+  if (initialized) {
+    return;
   }
+  if (loadingPromise) {
+    return loadingPromise;
+  }
+  loadingPromise = (async () => {
+    const mode = await readRulesStorageMode();
+    rulesStorageModeState.set(mode);
+    rulesState.set(await readRulesFromMode(mode));
+    initialized = true;
+  })().finally(() => {
+    loadingPromise = undefined;
+  });
+  return loadingPromise;
 }
 
-export const rules = createSyncStorage<MatchRule[]>('rules', [], (value) =>
-  value.map((rule) => ({ ...rule, enabled: rule.enabled ?? true })),
-)
+async function persistRules(nextRules: MatchRule[]) {
+  await ensureInitialized();
+  const mode = get(rulesStorageModeState);
+  const normalized = normalizeRules(nextRules);
+  await writeRulesToMode(mode, normalized);
+  return normalized;
+}
+
+export const rulesStorageMode = {
+  subscribe: rulesStorageModeState.subscribe,
+};
+
+export async function setRulesStorageMode(
+  mode: RulesStorageMode,
+): Promise<void> {
+  await ensureInitialized();
+  const previousMode = get(rulesStorageModeState);
+  if (previousMode === mode) {
+    return;
+  }
+  const currentRules = await readRulesFromMode(previousMode);
+  await writeRulesToMode(mode, currentRules);
+  await writeRulesStorageMode(mode);
+  rulesStorageModeState.set(mode);
+  rulesState.set(currentRules);
+}
+
+export const rules = {
+  subscribe(run: (value: MatchRule[]) => void) {
+    ensureInitialized().catch((error) => {
+      console.error("Failed to initialize rules store", error);
+    });
+    return rulesState.subscribe(run);
+  },
+  set(value: MatchRule[]) {
+    const normalized = normalizeRules(value);
+    rulesState.set(normalized);
+    void persistRules(normalized).catch((error) => {
+      console.error("Failed to persist rules", error);
+    });
+  },
+  update(updater: (value: MatchRule[]) => MatchRule[]) {
+    const nextValue = updater(get(rulesState));
+    rules.set(nextValue);
+  },
+};
+
+export async function addRule(rule: MatchRule): Promise<void> {
+  await ensureInitialized();
+  const normalized = await persistRules([rule, ...get(rulesState)]);
+  rulesState.set(normalized);
+}

--- a/src/entrypoints/options/store.ts
+++ b/src/entrypoints/options/store.ts
@@ -9,6 +9,8 @@ import {
 import { MatchRule } from "$lib/url";
 import { get, writable } from "svelte/store";
 
+const STORAGE_QUOTA_EXCEEDED_RE = /quota/i;
+
 const rulesStorageModeState = writable<RulesStorageMode>("sync");
 const rulesState = writable<MatchRule[]>([]);
 
@@ -39,6 +41,16 @@ async function persistRules(nextRules: MatchRule[]) {
   const normalized = normalizeRules(nextRules);
   await writeRulesToMode(mode, normalized);
   return normalized;
+}
+
+export function isStorageQuotaExceededError(error: unknown): boolean {
+  if (error instanceof Error) {
+    return STORAGE_QUOTA_EXCEEDED_RE.test(error.message);
+  }
+  if (typeof error === "string") {
+    return STORAGE_QUOTA_EXCEEDED_RE.test(error);
+  }
+  return false;
 }
 
 export const rulesStorageMode = {
@@ -83,5 +95,10 @@ export const rules = {
 export async function addRule(rule: MatchRule): Promise<void> {
   await ensureInitialized();
   const normalized = await persistRules([rule, ...get(rulesState)]);
+  rulesState.set(normalized);
+}
+
+export async function replaceRules(nextRules: MatchRule[]): Promise<void> {
+  const normalized = await persistRules(nextRules);
   rulesState.set(normalized);
 }

--- a/src/lib/check.ts
+++ b/src/lib/check.ts
@@ -1,3 +1,4 @@
+import { readActiveRules } from './storage'
 import { matchRule, MatchRule } from './url'
 
 export type CheckResult = {
@@ -6,13 +7,7 @@ export type CheckResult = {
 }
 
 export async function getEnabledRules() {
-  return (
-    (
-      await browser.storage.sync.get<{
-        rules?: MatchRule[]
-      }>('rules')
-    ).rules ?? []
-  ).filter((it) => it.enabled ?? true)
+  return (await readActiveRules()).filter((it) => it.enabled ?? true)
 }
 
 export interface CheckOptions {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,63 @@
+import { MatchRule } from "./url";
+
+export type RulesStorageMode = "sync" | "local";
+
+export const RULES_KEY = "rules";
+export const RULES_STORAGE_MODE_KEY = "rules-storage-mode";
+
+export function normalizeRules(rules: MatchRule[]): MatchRule[] {
+  return rules.map((rule) => ({ ...rule, enabled: rule.enabled ?? true }));
+}
+
+function hasBrowserStorageApi() {
+  return typeof browser !== "undefined" && !!browser.storage;
+}
+
+export function getStorageArea(mode: RulesStorageMode) {
+  return browser.storage[mode];
+}
+
+export async function readRulesStorageMode(): Promise<RulesStorageMode> {
+  if (!hasBrowserStorageApi()) {
+    return "sync";
+  }
+  const result = await browser.storage.local.get(RULES_STORAGE_MODE_KEY);
+  const mode = result[RULES_STORAGE_MODE_KEY];
+  return mode === "local" ? "local" : "sync";
+}
+
+export async function writeRulesStorageMode(
+  mode: RulesStorageMode,
+): Promise<void> {
+  if (!hasBrowserStorageApi()) {
+    return;
+  }
+  await browser.storage.local.set({ [RULES_STORAGE_MODE_KEY]: mode });
+}
+
+export async function readRulesFromMode(
+  mode: RulesStorageMode,
+): Promise<MatchRule[]> {
+  if (!hasBrowserStorageApi()) {
+    return [];
+  }
+  const result = await getStorageArea(mode).get(RULES_KEY);
+  return normalizeRules(
+    (result[RULES_KEY] as MatchRule[] | undefined) ?? [],
+  );
+}
+
+export async function writeRulesToMode(
+  mode: RulesStorageMode,
+  rules: MatchRule[],
+): Promise<void> {
+  if (!hasBrowserStorageApi()) {
+    return;
+  }
+  await getStorageArea(mode).set({ [RULES_KEY]: normalizeRules(rules) });
+}
+
+export async function readActiveRules(): Promise<MatchRule[]> {
+  const mode = await readRulesStorageMode();
+  return readRulesFromMode(mode);
+}


### PR DESCRIPTION
Currently adding a lot of redirect urls, chrome complains that: `Resource::kQuotaBytesPerItem quota exceeded`.
This PR adds the browsers localStorage as a backup if trying to save to syncStorage fails.

All rules are mirrored in syncStorage and localStorage and by default syncStorage is prefered when reading the rules from storage.
If an error occurs while writing rules to syncStorage, localStorage is marked as "preferred".
Every time a rule is added/deleted/edited we try writing the new rule set to both sync and local storage; if the write to syncStorage succeeds, syncStorage onca again gets marked as the "preferred".